### PR TITLE
fix conky config path on iso

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ ${ISO}:
 	mkdir -p ${CONFDIR}
 	git clone -q ${CONFREPO} tmp/configs
 	${MAKE} -Ctmp/configs CONFDIR="${CONFDIR}" install
+	cp airrootfs/home/liveuser/.config/conky/.conkyrc ../../.conkyrc
 	cp -f pacman.conf airootfs/etc/pacman.conf
 	@# Build ISO
 	${MKARCHISO} ${MKARCHISOFLAGS}


### PR DESCRIPTION
conky went into .config.. normally conky's config file is ~/.conkyrc