### PR TITLE
Fetch script from github

### DIFF
--- a/airootfs/home/liveuser/.zlogin
+++ b/airootfs/home/liveuser/.zlogin
@@ -1,3 +1,3 @@
-alias virbos-installer="curl https://raw.githubusercontent.com/Virbos/virbos-livescripts/master/virbos-setup | bash"
+alias virbos-setup="curl https://raw.githubusercontent.com/Virbos/virbos-livescripts/master/virbos-setup | bash"
 touch ~/.Xauthority
 startx

--- a/airootfs/home/liveuser/.zlogin
+++ b/airootfs/home/liveuser/.zlogin
@@ -1,2 +1,3 @@
+alias virbos-installer="curl https://raw.githubusercontent.com/Virbos/virbos-livescripts/master/virbos-setup | bash"
 touch ~/.Xauthority
 startx

--- a/airootfs/root/.zlogin
+++ b/airootfs/root/.zlogin
@@ -5,3 +5,4 @@ fi
 
 ~/.automated_script.sh
 
+alias virbos-installer="curl https://raw.githubusercontent.com/Virbos/virbos-livescripts/master/virbos-setup | bash"

--- a/airootfs/root/.zlogin
+++ b/airootfs/root/.zlogin
@@ -5,4 +5,4 @@ fi
 
 ~/.automated_script.sh
 
-alias virbos-installer="curl https://raw.githubusercontent.com/Virbos/virbos-livescripts/master/virbos-setup | bash"
+alias virbos-setup="curl https://raw.githubusercontent.com/Virbos/virbos-livescripts/master/virbos-setup | bash"

--- a/airootfs/root/.zlogin
+++ b/airootfs/root/.zlogin
@@ -5,5 +5,3 @@ fi
 
 ~/.automated_script.sh
 
-echo "Starting Sway"
-sway

--- a/packages.x86_64
+++ b/packages.x86_64
@@ -123,7 +123,6 @@ xl2tpd
 zsh
 
 # virbos repo
-virbos-livescripts
 virbos-logos
 maxfetch
 alacritty-sixel


### PR DESCRIPTION
The installation script is now fetched automagically from github instead of using a installed package.

One benefit is that all next ISOs with a valid keyring can use up to date installation script
the script can be updated while a ISO is running and the ISO will use the updated one automatically (this does require the script not to be run though however it should not interfere with the older one from functioning)